### PR TITLE
Fixed broken example in README describing Yeah.js parameter passing w/ includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ There's no need for all that in a static website. If you do have a case for it, 
 ```ejs
 en.ejs: <%- include('_content.ejs', {lang: 'en'}) %>
 fr.ejs: <%- include('_content.ejs', {lang: 'fr'}) %>
-_content.ejs: <%= content[lang].body %> (use either content/en.md or content/fr.md)
+_content.ejs: <%= content[locals.lang].body %> (use either content/en.md or content/fr.md)
 ```
 
 #### How do I add pagination?


### PR DESCRIPTION
The multilingual example would not work, threw me off when I tried it on a personal website. After much debugging I discovered that you need to use the `locals` object as described in Yeah.js to access a passed parameter in the included template. I.e.
`<%- include('_content.ejs', {lang: 'en'}) -%>` would be read in `_content.ejs` as `<% if (locals.lang == 'en') { %>`.